### PR TITLE
Modified layout of the application

### DIFF
--- a/ariadne/__init__.py
+++ b/ariadne/__init__.py
@@ -1,4 +1,4 @@
-
 from ._version import get_versions
-__version__ = get_versions()['version']
+
+__version__ = get_versions()["version"]
 del get_versions

--- a/ariadne/_version.py
+++ b/ariadne/_version.py
@@ -1,4 +1,3 @@
-
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -58,17 +57,18 @@ HANDLERS = {}
 
 def register_vcs_handler(vcs, method):  # decorator
     """Decorator to mark a method as the handler for a particular VCS."""
+
     def decorate(f):
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:
             HANDLERS[vcs] = {}
         HANDLERS[vcs][method] = f
         return f
+
     return decorate
 
 
-def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
-                env=None):
+def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=None):
     """Call the given command(s)."""
     assert isinstance(commands, list)
     p = None
@@ -76,10 +76,13 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
         try:
             dispcmd = str([c] + args)
             # remember shell=False, so use git.cmd on windows, not just git
-            p = subprocess.Popen([c] + args, cwd=cwd, env=env,
-                                 stdout=subprocess.PIPE,
-                                 stderr=(subprocess.PIPE if hide_stderr
-                                         else None))
+            p = subprocess.Popen(
+                [c] + args,
+                cwd=cwd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=(subprocess.PIPE if hide_stderr else None),
+            )
             break
         except EnvironmentError:
             e = sys.exc_info()[1]
@@ -116,16 +119,19 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
     for i in range(3):
         dirname = os.path.basename(root)
         if dirname.startswith(parentdir_prefix):
-            return {"version": dirname[len(parentdir_prefix):],
-                    "full-revisionid": None,
-                    "dirty": False, "error": None, "date": None}
+            return {
+                "version": dirname[len(parentdir_prefix) :],
+                "full-revisionid": None,
+                "dirty": False,
+                "error": None,
+                "date": None,
+            }
         else:
             rootdirs.append(root)
             root = os.path.dirname(root)  # up a level
 
     if verbose:
-        print("Tried directories %s but none started with prefix %s" %
-              (str(rootdirs), parentdir_prefix))
+        print("Tried directories %s but none started with prefix %s" % (str(rootdirs), parentdir_prefix))
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
 
@@ -181,7 +187,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
+    tags = set([r[len(TAG) :] for r in refs if r.startswith(TAG)])
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -190,7 +196,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = set([r for r in refs if re.search(r'\d', r)])
+        tags = set([r for r in refs if re.search(r"\d", r)])
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
@@ -198,19 +204,26 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
-            r = ref[len(tag_prefix):]
+            r = ref[len(tag_prefix) :]
             if verbose:
                 print("picking %s" % r)
-            return {"version": r,
-                    "full-revisionid": keywords["full"].strip(),
-                    "dirty": False, "error": None,
-                    "date": date}
+            return {
+                "version": r,
+                "full-revisionid": keywords["full"].strip(),
+                "dirty": False,
+                "error": None,
+                "date": date,
+            }
     # no suitable tags, so version is "0+unknown", but full hex is still there
     if verbose:
         print("no suitable tags, using unknown + full revision id")
-    return {"version": "0+unknown",
-            "full-revisionid": keywords["full"].strip(),
-            "dirty": False, "error": "no suitable tags", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": keywords["full"].strip(),
+        "dirty": False,
+        "error": "no suitable tags",
+        "date": None,
+    }
 
 
 @register_vcs_handler("git", "pieces_from_vcs")
@@ -225,8 +238,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
 
-    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root,
-                          hide_stderr=True)
+    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root, hide_stderr=True)
     if rc != 0:
         if verbose:
             print("Directory %s not under git control" % root)
@@ -234,10 +246,9 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
-    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
-                                          "--always", "--long",
-                                          "--match", "%s*" % tag_prefix],
-                                   cwd=root)
+    describe_out, rc = run_command(
+        GITS, ["describe", "--tags", "--dirty", "--always", "--long", "--match", "%s*" % tag_prefix], cwd=root
+    )
     # --long was added in git-1.5.5
     if describe_out is None:
         raise NotThisMethod("'git describe' failed")
@@ -260,17 +271,16 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     dirty = git_describe.endswith("-dirty")
     pieces["dirty"] = dirty
     if dirty:
-        git_describe = git_describe[:git_describe.rindex("-dirty")]
+        git_describe = git_describe[: git_describe.rindex("-dirty")]
 
     # now we have TAG-NUM-gHEX or HEX
 
     if "-" in git_describe:
         # TAG-NUM-gHEX
-        mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
+        mo = re.search(r"^(.+)-(\d+)-g([0-9a-f]+)$", git_describe)
         if not mo:
             # unparseable. Maybe git-describe is misbehaving?
-            pieces["error"] = ("unable to parse git-describe output: '%s'"
-                               % describe_out)
+            pieces["error"] = "unable to parse git-describe output: '%s'" % describe_out
             return pieces
 
         # tag
@@ -279,10 +289,9 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = ("tag '%s' doesn't start with prefix '%s'"
-                               % (full_tag, tag_prefix))
+            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (full_tag, tag_prefix)
             return pieces
-        pieces["closest-tag"] = full_tag[len(tag_prefix):]
+        pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 
         # distance: number of commits since tag
         pieces["distance"] = int(mo.group(2))
@@ -293,13 +302,11 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     else:
         # HEX: no tags
         pieces["closest-tag"] = None
-        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"],
-                                    cwd=root)
+        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"], cwd=root)
         pieces["distance"] = int(count_out)  # total number of commits
 
     # commit date: see ISO-8601 comment in git_versions_from_keywords()
-    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"],
-                       cwd=root)[0].strip()
+    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"], cwd=root)[0].strip()
     pieces["date"] = date.strip().replace(" ", "T", 1).replace(" ", "", 1)
 
     return pieces
@@ -330,8 +337,7 @@ def render_pep440(pieces):
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = "0+untagged.%d.g%s" % (pieces["distance"],
-                                          pieces["short"])
+        rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -445,11 +451,13 @@ def render_git_describe_long(pieces):
 def render(pieces, style):
     """Render the given version pieces into the requested style."""
     if pieces["error"]:
-        return {"version": "unknown",
-                "full-revisionid": pieces.get("long"),
-                "dirty": None,
-                "error": pieces["error"],
-                "date": None}
+        return {
+            "version": "unknown",
+            "full-revisionid": pieces.get("long"),
+            "dirty": None,
+            "error": pieces["error"],
+            "date": None,
+        }
 
     if not style or style == "default":
         style = "pep440"  # the default
@@ -469,9 +477,13 @@ def render(pieces, style):
     else:
         raise ValueError("unknown style '%s'" % style)
 
-    return {"version": rendered, "full-revisionid": pieces["long"],
-            "dirty": pieces["dirty"], "error": None,
-            "date": pieces.get("date")}
+    return {
+        "version": rendered,
+        "full-revisionid": pieces["long"],
+        "dirty": pieces["dirty"],
+        "error": None,
+        "date": pieces.get("date"),
+    }
 
 
 def get_versions():
@@ -485,8 +497,7 @@ def get_versions():
     verbose = cfg.verbose
 
     try:
-        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix,
-                                          verbose)
+        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix, verbose)
     except NotThisMethod:
         pass
 
@@ -495,13 +506,16 @@ def get_versions():
         # versionfile_source is the relative path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
-        for i in cfg.versionfile_source.split('/'):
+        for i in cfg.versionfile_source.split("/"):
             root = os.path.dirname(root)
     except NameError:
-        return {"version": "0+unknown", "full-revisionid": None,
-                "dirty": None,
-                "error": "unable to find root of source tree",
-                "date": None}
+        return {
+            "version": "0+unknown",
+            "full-revisionid": None,
+            "dirty": None,
+            "error": "unable to find root of source tree",
+            "date": None,
+        }
 
     try:
         pieces = git_pieces_from_vcs(cfg.tag_prefix, root, verbose)
@@ -515,6 +529,10 @@ def get_versions():
     except NotThisMethod:
         pass
 
-    return {"version": "0+unknown", "full-revisionid": None,
-            "dirty": None,
-            "error": "unable to compute version", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": None,
+        "dirty": None,
+        "error": "unable to compute version",
+        "date": None,
+    }

--- a/ariadne/widgets.py
+++ b/ariadne/widgets.py
@@ -25,7 +25,10 @@ from qtpy.QtWidgets import (
     QComboBox,
     QLabel,
     QTabWidget,
+    QSplitter,
+    QFrame,
 )
+from qtpy.QtCore import Qt
 
 from .models import SearchAndView
 
@@ -173,9 +176,70 @@ class QtRunExperiment(QWidget):
         vbox2.addStretch(stretch=1)
         hbox.addLayout(vbox2)
 
-
         vbox.addLayout(hbox)
         self.setLayout(vbox)
+
+
+class QtOrganizeQueueRight(QSplitter):
+    def __init__(self, model, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.model = model
+
+        self.setOrientation(Qt.Vertical)
+
+        self._frame_top = QFrame(self)
+        self._frame_top.setFrameShape(QFrame.StyledPanel)
+
+        self._frame_bottom = QFrame(self)
+        self._frame_bottom.setFrameShape(QFrame.StyledPanel)
+
+        self.addWidget(self._frame_top)
+        self.addWidget(self._frame_bottom)
+
+        self._plan_editor = QtRePlanEditor(model)
+        self._plan_history = QtRePlanHistory(model)
+
+        vbox = QVBoxLayout()
+        vbox.addWidget(self._plan_editor, stretch=1)
+        self._frame_top.setLayout(vbox)
+
+        vbox = QVBoxLayout()
+        vbox.addWidget(self._plan_history, stretch=1)
+        self._frame_bottom.setLayout(vbox)
+
+        h = self.sizeHint().height()
+        self.setSizes([h, h])
+
+
+class QtOrganizeQueueSplitter(QSplitter):
+    def __init__(self, model, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.model = model
+
+        self.setOrientation(Qt.Horizontal)
+
+        self._frame_left = QFrame(self)
+        self._frame_left.setFrameShape(QFrame.StyledPanel)
+
+        self._frame_right = QFrame(self)
+        self._frame_right.setFrameShape(QFrame.StyledPanel)
+
+        self.addWidget(self._frame_left)
+        self.addWidget(self._frame_right)
+
+        self._plan_editor = QtRePlanQueue(model)
+        self._right_splitter = QtOrganizeQueueRight(model)
+
+        vbox = QVBoxLayout()
+        vbox.addWidget(self._plan_editor, stretch=1)
+        self._frame_left.setLayout(vbox)
+
+        vbox = QVBoxLayout()
+        vbox.addWidget(self._right_splitter, stretch=1)
+        self._frame_right.setLayout(vbox)
+
+        w = self.sizeHint().width()
+        self.setSizes([w, w])
 
 
 class QtOrganizeQueue(QWidget):
@@ -184,14 +248,7 @@ class QtOrganizeQueue(QWidget):
         self.model = model
 
         hbox = QHBoxLayout()
-        vbox1 = QVBoxLayout()
-        vbox1.addWidget(QtRePlanQueue(model), stretch=1)
-        hbox.addLayout(vbox1)
-        vbox2 = QVBoxLayout()
-        vbox2.addWidget(QtRePlanEditor(model), stretch=1)
-        vbox2.addWidget(QtRePlanHistory(model), stretch=1)
-        hbox.addLayout(vbox2)
-
+        hbox.addWidget(QtOrganizeQueueSplitter(model))
         self.setLayout(hbox)
 
 

--- a/ariadne/widgets.py
+++ b/ariadne/widgets.py
@@ -147,7 +147,7 @@ class QtSearchAndView(QWidget):
         layout.addLayout(plot_layout)
 
 
-class QtRunEngineManager(QWidget):
+class QtRunExperiment(QWidget):
     def __init__(self, model, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.model = model
@@ -163,16 +163,36 @@ class QtRunEngineManager(QWidget):
         vbox.addLayout(hbox)
 
         hbox = QHBoxLayout()
+
         vbox1 = QVBoxLayout()
-        vbox1.addWidget(QtRePlanEditor(model), stretch=1)
+        vbox1.addWidget(QtReRunningPlan(model), stretch=1)
+        vbox1.addWidget(QtRePlanQueue(model), stretch=2)
+        hbox.addLayout(vbox1)
+        vbox2 = QVBoxLayout()
+        vbox2.addWidget(QtRePlanEditor(model), stretch=1)
+        vbox2.addStretch(stretch=1)
+        hbox.addLayout(vbox2)
+
+
+        vbox.addLayout(hbox)
+        self.setLayout(vbox)
+
+
+class QtOrganizeQueue(QWidget):
+    def __init__(self, model, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.model = model
+
+        hbox = QHBoxLayout()
+        vbox1 = QVBoxLayout()
         vbox1.addWidget(QtRePlanQueue(model), stretch=1)
         hbox.addLayout(vbox1)
         vbox2 = QVBoxLayout()
-        vbox2.addWidget(QtReRunningPlan(model), stretch=1)
-        vbox2.addWidget(QtRePlanHistory(model), stretch=2)
+        vbox2.addWidget(QtRePlanEditor(model), stretch=1)
+        vbox2.addWidget(QtRePlanHistory(model), stretch=1)
         hbox.addLayout(vbox2)
-        vbox.addLayout(hbox)
-        self.setLayout(vbox)
+
+        self.setLayout(hbox)
 
 
 class QtViewer(QTabWidget):
@@ -182,10 +202,11 @@ class QtViewer(QTabWidget):
 
         self.setTabPosition(QTabWidget.West)
 
-        self._re_manager = QtRunEngineManager(model.run_engine)
-        # TODO: putting the widget in QScrollArea doesn't work (the widget is not scaled with the window)
-        #   It can be a configuration problem.
-        self.addTab(self._re_manager, "Run Engine")
+        self._run_experiment = QtRunExperiment(model.run_engine)
+        self.addTab(self._run_experiment, "Run Experiment")
+
+        self._organize_queue = QtOrganizeQueue(model.run_engine)
+        self.addTab(self._organize_queue, "Organize Queue")
 
         self._search_and_view = QtSearchAndView(SearchAndView(model.search, model.auto_plot_builder))
         self.addTab(self._search_and_view, "Data Broker")

--- a/setup.py
+++ b/setup.py
@@ -19,40 +19,41 @@ This may be due to an out-of-date pip. Make sure you have pip >= 9.0.1.
 Upgrade pip like so:
 
 pip install --upgrade pip
-""".format(*(sys.version_info[:2] + min_version))
+""".format(
+        *(sys.version_info[:2] + min_version)
+    )
     sys.exit(error)
 
 here = path.abspath(path.dirname(__file__))
 
-with open(path.join(here, 'README.rst'), encoding='utf-8') as readme_file:
+with open(path.join(here, "README.rst"), encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
-with open(path.join(here, 'requirements.txt')) as requirements_file:
+with open(path.join(here, "requirements.txt")) as requirements_file:
     # Parse requirements.txt, ignoring any commented-out lines.
-    requirements = [line for line in requirements_file.read().splitlines()
-                    if not line.startswith('#')]
+    requirements = [line for line in requirements_file.read().splitlines() if not line.startswith("#")]
 
 
 setup(
-    name='ariadne',
+    name="ariadne",
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     description="Acquisition GUI for NSLS-II BMM beamline",
     long_description=readme,
     author="Brookhaven National Lab",
-    author_email='',
-    url='https://github.com//ariadne',
-    python_requires='>={}'.format('.'.join(str(n) for n in min_version)),
-    packages=find_packages(exclude=['docs', 'tests']),
+    author_email="",
+    url="https://github.com//ariadne",
+    python_requires=">={}".format(".".join(str(n) for n in min_version)),
+    packages=find_packages(exclude=["docs", "tests"]),
     entry_points={
-        'console_scripts': [
+        "console_scripts": [
             "ariadne = ariadne.main:main"
             # 'command = some.module:some_function',
         ],
     },
     include_package_data=True,
     package_data={
-        'ariadne': [
+        "ariadne": [
             # When adding files here, remember to update MANIFEST.in as well,
             # or else they will not be included in the distribution on PyPI!
             # 'path/to/data_file',
@@ -61,8 +62,8 @@ setup(
     install_requires=requirements,
     license="BSD (3-clause)",
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 3',
+        "Development Status :: 2 - Pre-Alpha",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3",
     ],
 )


### PR DESCRIPTION
Modified layout of the application to provide space for custom BMM widget: 

- 'Run Engine' tab is split into 'Run Experiment' and 'Organize Queue' tabs. 
- The space for the custom BMM plan editor widget is left in 'Run Experiment' tab. 
- The 'Organize Queue' tab contains three widgets: Queue Widget, History Widget and generic Plan Editor.
- The widgets in 'Organize Queue' tab are organized using `QSplitter` widgets: the widgets could be resized or completely removed from the screen.
- The project was formatted using `black`, which generated some irrelevant code changes.