### PR TITLE
Viewer widget on the Experiment Control tab

### DIFF
--- a/ariadne/main.py
+++ b/ariadne/main.py
@@ -11,6 +11,14 @@ def main(argv=None):
 
     parser = argparse.ArgumentParser(description="Ariadne: acquisition GUI for NSLS-II BMM beamline")
     parser.add_argument("--zmq", help="0MQ address")
+    parser.add_argument(
+        "--kafka-servers",
+        help="Kafka servers, comma-separated string, e.g. "
+        "kafka1.nsls2.bnl.gov:9092,kafka2.nsls2.bnl.gov:9092,kafka3.nsls2.bnl.gov:9092",
+    )
+    parser.add_argument(
+        "--kafka-topics", help="Kafka servers, comma-separated string, e.g. bmm.bluesky.runengine.documents"
+    )
     parser.add_argument("--catalog", help="Databroker catalog")
     args = parser.parse_args(argv)
 
@@ -22,7 +30,14 @@ def main(argv=None):
 
         # Optional: Receive live streaming data.
         if args.zmq:
-            SETTINGS.subscribe_to.append(args.zmq)
+            SETTINGS.subscribe_to.append({"protocol": "zmq", "zmq_addr": args.zmq})
+        if args.kafka_servers and args.kafka_topics:
+            kafka_servers = args.kafka_servers
+            kafka_topics = args.kafka_topics.split(",")
+            kafka_topics = [_.strip() for _ in kafka_topics]
+            source = {"protocol": "kafka", "servers": kafka_servers, "topics": kafka_topics}
+            SETTINGS.subscribe_to.append(source)
+
         viewer = Viewer()  # noqa: 401
 
 

--- a/ariadne/models.py
+++ b/ariadne/models.py
@@ -15,6 +15,12 @@ class SearchWithButton(Search):
         self.events.add(view=Event)
 
 
+class RunAndView:
+    def __init__(self, run_engine, auto_plot_builder):
+        self.run_engine = run_engine
+        self.auto_plot_builder = auto_plot_builder
+
+
 class SearchAndView:
     def __init__(self, search, auto_plot_builder):
         self.search = search

--- a/ariadne/viewer.py
+++ b/ariadne/viewer.py
@@ -116,49 +116,6 @@ class Viewer(ViewerModel):
             else:
                 print(f"Unknown protocol: {source['protocol']}")
 
-            # # from bluesky_widgets.qt.zmq_dispatcher import RemoteDispatcher
-            # import msgpack
-            # import msgpack_numpy as mpn
-            #
-            # from bluesky_kafka import RemoteDispatcher
-            # from functools import partial
-            #
-            # # from bluesky_widgets.qt.zmq_dispatcher import RemoteDispatcher
-            # from bluesky_widgets.utils.streaming import (
-            #     stream_documents_into_runs,
-            # )
-            #
-            # bootstrap_servers = "kafka1.nsls2.bnl.gov:9092,kafka2.nsls2.bnl.gov:9092,kafka3.nsls2.bnl.gov:9092"
-            # kafka_deserializer = partial(msgpack.loads, object_hook=mpn.decode)
-            # topics = ["bmm.bluesky.runengine.documents"]
-            # consumer_config = {"auto.commit.interval.ms": 100, "auto.offset.reset": "latest"}
-            #
-            # self.dispatcher = RemoteDispatcher(
-            #     topics=topics,
-            #     bootstrap_servers=bootstrap_servers,
-            #     group_id="widgets_test",
-            #     consumer_config=consumer_config,
-            # )
-            #
-            # self.dispatcher.subscribe(stream_documents_into_runs(self.auto_plot_builder.add_run))
-            #
-            # from qtpy.QtCore import QThread
-            #
-            # class DispatcherStart(QThread):
-            #     def __init__(self, dispatcher):
-            #         super().__init__()
-            #         self._dispatcher = dispatcher
-            #
-            #     def run(self):
-            #         self._dispatcher.start()
-            #
-            # self.dispatcher_thread = DispatcherStart(self.dispatcher)
-            # self.dispatcher_thread.start()
-            #
-            # # for address in SETTINGS.subscribe_to:
-            # #    dispatcher = RemoteDispatcher(address)
-            # #    dispatcher.subscribe(stream_documents_into_runs(self.auto_plot_builder.add_run))
-            # #    dispatcher.start()
         widget = QtViewer(self)
         self._window = Window(widget, show=show)
 

--- a/ariadne/viewer.py
+++ b/ariadne/viewer.py
@@ -3,6 +3,9 @@ import os
 from bluesky_widgets.models.auto_plot_builders import AutoLines
 from bluesky_widgets.models.run_engine_client import RunEngineClient
 from bluesky_widgets.qt import Window
+from bluesky_widgets.models.plot_specs import Axes, Figure
+from bluesky_widgets.models.plot_builders import Lines
+from bluesky_widgets.models.auto_plot_builders import AutoPlotter
 
 from .widgets import QtViewer
 from .models import SearchWithButton
@@ -16,11 +19,61 @@ class ViewerModel:
 
     def __init__(self):
         self.search = SearchWithButton(SETTINGS.catalog, columns=SETTINGS.columns)
-        self.auto_plot_builder = AutoLines(max_runs=3)
+        self.auto_plot_builder = AutoBMMPlot()
 
         self.run_engine = RunEngineClient(
             zmq_server_address=os.environ.get("QSERVER_ZMQ_ADDRESS", None),
         )
+
+
+class AutoBMMPlot(AutoPlotter):
+
+    def handle_new_stream(self, run, stream_name):
+        if stream_name != 'primary':
+            return
+
+        xx = run.metadata['start']['motors'][0]
+        to_plot = run.metadata['start'].get('plot_request', 'It')
+        models = []
+        figures = []
+        if to_plot == "It":
+            axes1 = Axes()
+            figure1 = Figure((axes1,), title="It/I0")
+            figures.append(figure1)
+            models.append(
+                Lines(x=xx, ys=['It/I0',], max_runs=1, axes=axes1)
+            )
+            axes2 = Axes()
+            figure2 = Figure((axes2,), title="I0")
+            figures.append(figure2)
+            models.append(
+                Lines(x=xx, ys=['I0',],    max_runs=1, axes=axes2)
+            )
+        elif to_plot == "I0":
+            axes = Axes()
+            figure = Figure((axes,), title="I0")
+            figures.append(figure)
+            models.append(
+                Lines(x=xx, ys=['I0',],    max_runs=1, axes=axes)
+            )
+        elif to_plot == "Ir":
+            axes1 = Axes()
+            axes2 = Axes()
+            figure = Figure((axes1, axes2), title='It and I0')
+            figures.append(figure)
+            models.append(
+                Lines(x=xx, ys=['It/I0',], max_runs=1, axes=axes1)
+            )
+            models.append(
+                Lines(x=xx, ys=['I0',],    max_runs=1, axes=axes2)
+            )
+        else:
+            # Plot nothing.
+            pass
+        for model in models:
+            model.add_run(run)
+            self.plot_builders.append(model) 
+        self.figures.extend(figures) 
 
 
 class Viewer(ViewerModel):
@@ -33,16 +86,48 @@ class Viewer(ViewerModel):
     def __init__(self, *, show=True, title="Demo App"):
         # TODO Where does title thread through?
         super().__init__()
-        if SETTINGS.subscribe_to:
-            from bluesky_widgets.qt.zmq_dispatcher import RemoteDispatcher
+        if True: # SETTINGS.subscribe_to:
+            # from bluesky_widgets.qt.zmq_dispatcher import RemoteDispatcher
+            import msgpack
+            import msgpack_numpy as mpn
+
+            from bluesky_kafka import RemoteDispatcher
+            from functools import partial
+            # from bluesky_widgets.qt.zmq_dispatcher import RemoteDispatcher
             from bluesky_widgets.utils.streaming import (
                 stream_documents_into_runs,
+                )
+ 
+            bootstrap_servers = "kafka1.nsls2.bnl.gov:9092,kafka2.nsls2.bnl.gov:9092,kafka3.nsls2.bnl.gov:9092"
+            kafka_deserializer = partial(msgpack.loads, object_hook=mpn.decode)
+            topics = ["bmm.bluesky.runengine.documents"]
+            consumer_config = {"auto.commit.interval.ms": 100, "auto.offset.reset": "latest"}
+
+            self.dispatcher = RemoteDispatcher(
+                topics=topics,
+                bootstrap_servers=bootstrap_servers,
+                group_id="widgets_test",
+                consumer_config=consumer_config,
             )
 
-            for address in SETTINGS.subscribe_to:
-                dispatcher = RemoteDispatcher(address)
-                dispatcher.subscribe(stream_documents_into_runs(self.auto_plot_builder.add_run))
-                dispatcher.start()
+            self.dispatcher.subscribe(stream_documents_into_runs(self.auto_plot_builder.add_run))
+            
+            from qtpy.QtCore import QThread
+            class DispatcherStart(QThread):
+                def __init__(self, dispatcher):
+                    super().__init__()
+                    self._dispatcher = dispatcher
+
+                def run(self):
+                    self._dispatcher.start()
+
+            self.dispatcher_thread = DispatcherStart(self.dispatcher)
+            self.dispatcher_thread.start()
+            
+            #for address in SETTINGS.subscribe_to:
+            #    dispatcher = RemoteDispatcher(address)
+            #    dispatcher.subscribe(stream_documents_into_runs(self.auto_plot_builder.add_run))
+            #    dispatcher.start()
         widget = QtViewer(self)
         self._window = Window(widget, show=show)
 

--- a/ariadne/viewer.py
+++ b/ariadne/viewer.py
@@ -1,6 +1,5 @@
 import os
 
-from bluesky_widgets.models.auto_plot_builders import AutoLines
 from bluesky_widgets.models.run_engine_client import RunEngineClient
 from bluesky_widgets.qt import Window
 from bluesky_widgets.models.plot_specs import Axes, Figure
@@ -85,11 +84,8 @@ class Viewer(ViewerModel):
                 dispatcher.start()
 
             elif source["protocol"] == "kafka":
-                import msgpack
-                import msgpack_numpy as mpn
                 from bluesky_kafka import RemoteDispatcher
                 from bluesky_widgets.utils.streaming import stream_documents_into_runs
-                from functools import partial
                 from qtpy.QtCore import QThread
 
                 bootstrap_servers = source["servers"]

--- a/ariadne/widgets.py
+++ b/ariadne/widgets.py
@@ -30,7 +30,7 @@ from qtpy.QtWidgets import (
 )
 from qtpy.QtCore import Qt
 
-from .models import SearchAndView
+from .models import RunAndView, SearchAndView
 from .widget_xafs import PlanEditorXafs
 
 
@@ -157,11 +157,11 @@ class QtRunExperiment(QWidget):
         self.model = model
         vbox = QVBoxLayout()
         hbox = QHBoxLayout()
-        hbox.addWidget(QtReManagerConnection(model))
-        hbox.addWidget(QtReEnvironmentControls(model))
-        hbox.addWidget(QtReQueueControls(model))
-        hbox.addWidget(QtReExecutionControls(model))
-        hbox.addWidget(QtReStatusMonitor(model))
+        hbox.addWidget(QtReManagerConnection(model.run_engine))
+        hbox.addWidget(QtReEnvironmentControls(model.run_engine))
+        hbox.addWidget(QtReQueueControls(model.run_engine))
+        hbox.addWidget(QtReExecutionControls(model.run_engine))
+        hbox.addWidget(QtReStatusMonitor(model.run_engine))
 
         hbox.addStretch()
         vbox.addLayout(hbox)
@@ -169,12 +169,13 @@ class QtRunExperiment(QWidget):
         hbox = QHBoxLayout()
 
         vbox1 = QVBoxLayout()
-        vbox1.addWidget(QtReRunningPlan(model), stretch=1)
-        vbox1.addWidget(QtRePlanQueue(model), stretch=2)
+        vbox1.addWidget(QtReRunningPlan(model.run_engine), stretch=1)
+        vbox1.addWidget(QtRePlanQueue(model.run_engine), stretch=2)
         hbox.addLayout(vbox1)
         vbox2 = QVBoxLayout()
-        vbox2.addWidget(QtRePlanEditor(model), stretch=1)
-        vbox2.addWidget(PlanEditorXafs(model), stretch=1)
+        vbox2.addWidget(QtFigures(model.auto_plot_builder.figures))
+        # vbox2.addWidget(QtRePlanEditor(model), stretch=1)
+        # vbox2.addWidget(PlanEditorXafs(model), stretch=1)
         hbox.addLayout(vbox2)
 
         vbox.addLayout(hbox)
@@ -291,7 +292,7 @@ class QtViewer(QTabWidget):
 
         self.setTabPosition(QTabWidget.West)
 
-        self._run_experiment = QtRunExperiment(model.run_engine)
+        self._run_experiment = QtRunExperiment(RunAndView(model.run_engine, model.auto_plot_builder))
         self.addTab(self._run_experiment, "Run Experiment")
 
         self._organize_queue = QtOrganizeQueue(model.run_engine)

--- a/ariadne/widgets.py
+++ b/ariadne/widgets.py
@@ -181,6 +181,37 @@ class QtRunExperiment(QWidget):
         self.setLayout(vbox)
 
 
+class QtOrganizeQueueLeft(QSplitter):
+    def __init__(self, model, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.model = model
+
+        self.setOrientation(Qt.Vertical)
+
+        self._frame_top = QFrame(self)
+        self._frame_top.setFrameShape(QFrame.StyledPanel)
+
+        self._frame_bottom = QFrame(self)
+        self._frame_bottom.setFrameShape(QFrame.StyledPanel)
+
+        self.addWidget(self._frame_top)
+        self.addWidget(self._frame_bottom)
+
+        self._plan_editor = PlanEditorXafs(model)
+        self._plan_history = QtRePlanQueue(model)
+
+        vbox = QVBoxLayout()
+        vbox.addWidget(self._plan_editor, stretch=1)
+        self._frame_top.setLayout(vbox)
+
+        vbox = QVBoxLayout()
+        vbox.addWidget(self._plan_history, stretch=1)
+        self._frame_bottom.setLayout(vbox)
+
+        h = self.sizeHint().height()
+        self.setSizes([h, h])
+
+
 class QtOrganizeQueueRight(QSplitter):
     def __init__(self, model, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -228,7 +259,7 @@ class QtOrganizeQueueSplitter(QSplitter):
         self.addWidget(self._frame_left)
         self.addWidget(self._frame_right)
 
-        self._plan_editor = QtRePlanQueue(model)
+        self._plan_editor = QtOrganizeQueueLeft(model)
         self._right_splitter = QtOrganizeQueueRight(model)
 
         vbox = QVBoxLayout()


### PR DESCRIPTION
Changes:

- Plan editing widget (generic and custom XAFS) were moved from Experiment Control tab to Organize Queue tab.

- Viewer widget was inserted into the Experiment Control tab.

- Option to subscribe to Kafka topic was added.

- CLI options `--kafka-servers` and `--kafka-topics` were added.

The program was tested at BMM beamline with the following options:

ariadne --catalog bmm --kafka-servers "kafka1.nsls2.bnl.gov:9092,kafka2.nsls2.bnl.gov:9092,kafka3.nsls2.bnl.gov:9092" --kafka-topics "bmm.bluesky.runengine.documents" 

Testing was performed with Run Engine Manager started with the following options:

 start-re-manager --keep-re --startup-dir  profile_collection_BMM/startup/ --kafka-server kafka1.nsls2.bnl.gov:9092 --kafka-topic bmm.bluesky.runengine.documents

![image](https://user-images.githubusercontent.com/46980826/118050696-c8580f00-b34d-11eb-9093-60b7f2bef145.png)

![image](https://user-images.githubusercontent.com/46980826/118051222-9e531c80-b34e-11eb-85f0-dc6ec3393f7d.png)

Some notes on the performance of the View widget:

- The widget is optimized for viewing prerecorded data. Additional options should be implemented in order for the widget to look natural as a primary data viewer for the Experiment Control tab. In particular the widget should not accumulate tabs. At the start of the new experiment it should close all existing tabs and create new ones. It may also be useful to have an option of tiled view of multiple plots for users with large screens (beamline screens are large). 

- The widget crashes the application if all tabs are closed. This should probably be fixed before the DEMO.
