### PR TITLE
Use log(It/I0)

### DIFF
--- a/ariadne/viewer.py
+++ b/ariadne/viewer.py
@@ -35,11 +35,11 @@ class AutoBMMPlot(AutoPlotter):
         figures = []
 
         if to_plot == "It":
-            y_keys = (("It/I0",), ("I0",))
+            y_keys = (("log(It/I0)",), ("I0",))
         elif to_plot == "I0":
             y_keys = (("I0",),)
         elif to_plot == "Ir":
-            y_keys = (("It/I0", "I0"),)
+            y_keys = (("log(It/I0)", "I0"),)
 
         for y_key in y_keys:
             key = (xx, y_key, to_plot)


### PR DESCRIPTION
Changed `It/I0` to use `log(It/I0)` instead.